### PR TITLE
fix: fixed connection and added db app to creation

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -4,8 +4,13 @@ const config = () => {
     switch(env){
         case 'dev':
         return {
-            bd_url : 'mongodb://172.19.0.3:27017/',
-            bd_options : { user : 'guia_app', pass : 'GuiaApp123' }
+            bd_url : 'mongodb://localhost:27017',
+            bd_options : {
+                useNewUrlParser: true,
+                useUnifiedTopology: true,
+                user : 'guia_app', pass : 'GuiaApp123',
+                dbName : 'app'
+            }
         }
     }
 }

--- a/server/config/init-mongo.js
+++ b/server/config/init-mongo.js
@@ -1,0 +1,2 @@
+db = db.getSiblingDB('app')
+db.new_collection.insert({ some_key: "some_value" })

--- a/server/db.js
+++ b/server/db.js
@@ -1,8 +1,12 @@
 const mongoose = require('mongoose');
 const config = require('./config/config')
 
-mongoose.connect(config.bd_url, config.bd_options);
-mongoose.set('useCreateIndex', true);
+async function connectToMongo(){
+    await mongoose.connect(config.bd_url, config.bd_options);
+    mongoose.set('useCreateIndex', true);
+}
+
+connectToMongo();
 
 mongoose.connection.on('connected', () => {
     console.log('Aplicação conectada ao banco de dados!')

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -3,11 +3,13 @@ services:
   mongo:
     image: mongo
     restart: always
+    ports:
+      - 27017:27017
     environment:
       MONGO_INITDB_ROOT_USERNAME: guia_app
       MONGO_INITDB_ROOT_PASSWORD: GuiaApp123
     volumes:
-      - mongo_guia_app:/data/db
+      - ./config/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js
   mongo-express:
     image: mongo-express
     restart: always

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const app = express();
 const bodyParser = require('body-parser');
-const db = require('./db');
+require('./db');
 
 
 app.use(bodyParser.json());


### PR DESCRIPTION
# Comentários
## docker-compose.yml
Estava faltando o campo ports para possibilitar que o nosso servidor que não está containeirizado possa "enxergar" o Banco de dados:
```docker-compose
ports:
      - 27017:27017
```
No mapeamento de volumes utilizaremos um recurso do mongo para criação do Banco de Dados inicial através de arquivo ```init-mongo.js```

## init-mongo.js
Este arquivo executa métodos do terminal do mongo (referência: https://docs.mongodb.com/manual/reference/method/db.getSiblingDB/index.html) e não pode ter ";" e nem "const" ou qualquer outra sintaxe do javascript senão falha na execução

## db.js
Foi criada uma função assíncrona para aguardar a conexão com o Banco de Dados pelo método mongoose.connect().

## server.js
Basta fazer um require do arquivo db.js, não precisamos atribuí-lo a uma variável, caso não formos utilizá-lo depois.

## config.js
Foram adicionadas as propriedades: 
```js
useNewUrlParser: true,
useUnifiedTopology: true,
```
para evitar warnings no console e url foi modificada para mongodb://localhost:27017.